### PR TITLE
Update to iOS compliance policy in Intune

### DIFF
--- a/content/en/configuration/intune/devices/compliance-policies/policies/apple-ios-and-ipad.md
+++ b/content/en/configuration/intune/devices/compliance-policies/policies/apple-ios-and-ipad.md
@@ -46,10 +46,10 @@ Placeholders such as `<ORGANISATION.GOV.AU>`, `<BLUEPRINT.GOV.AU>` and `<TENANT-
 
 | Item                                  |          Value |
 | ------------------------------------- | -------------: |
-| Minimum OS version                    |         14.8.1 |
+| Minimum OS version                    |         18.7.1 |
 | Maximum OS version                    | Not configured |
-| Minimum OS version for mobile devices |         18H107 |
-| Maximum OS version for mobile devices | Not configured |
+| Minimum OS build version              |         22H30  |
+| Maximum OS build version              | Not configured |
 
 #### Microsoft Defender for Endpoint
 


### PR DESCRIPTION
Update to iOS compliance policy in Intune:
- Updated 'Minimum OS version for mobile devices' to 'Minimum OS build version' to reflect changes in the Intune portal
- Updated 'Maximum OS version for mobile devices' to 'Maximum OS build version' to reflect changes in the Intune portal
- Updated Minimum OS and build versions to 18.7.1 and 22H30 to reflect oldest still supported version of iOS and latest security patch from Sept 2025.